### PR TITLE
scripts: expand the list of known network cards

### DIFF
--- a/scripts/handle_dut
+++ b/scripts/handle_dut
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 OKTET Labs Ltd. All rights reserved.
 #
-# Determine and add DUT script according to TE_ENV_IUT_EF_DUT
-# and TE_ENV_TST1_EF_DUT variables.
+# Determine and add DUT script according to TE_ENV_IUT_DUT
+# and TE_ENV_TST1_DUT variables.
 
-case "$TE_ENV_IUT_EF_DUT" in
+case "$TE_ENV_IUT_DUT" in
     medford)
         TE_EXTRA_OPTS+=" --script=dut/medford"
         ;;
@@ -28,6 +28,6 @@ case "$TE_ENV_IUT_EF_DUT" in
         ;;
 esac
 
-case "$TE_ENV_TST1_EF_DUT" in
+case "$TE_ENV_TST1_DUT" in
     ef100) TE_EXTRA_OPTS+=" --script=dut/ef100_tst" ;;
 esac

--- a/scripts/nic-pci2dut
+++ b/scripts/nic-pci2dut
@@ -33,6 +33,6 @@ export_nic_model() {
 }
 
 export_nic_model $TE_PCI_VENDOR_IUT_TST1 $TE_PCI_DEVICE_IUT_TST1 \
-    TE_ENV_IUT_EF_DUT
+    TE_ENV_IUT_DUT
 export_nic_model $TE_PCI_VENDOR_TST1_IUT $TE_PCI_DEVICE_TST1_IUT \
-    TE_ENV_TST1_EF_DUT
+    TE_ENV_TST1_DUT

--- a/scripts/nic-pci2dut
+++ b/scripts/nic-pci2dut
@@ -12,6 +12,16 @@ NIC_MODELS["1924:0a03"]="medford"
 # Solarflare Communications XtremeScale SFC9250 10/25/40/50/100G Ethernet Controller
 NIC_MODELS["1924:0b03"]="medford"
 
+# Mellanox Technologies MT27800 Family [ConnectX-5]
+NIC_MODELS["15b3:1017"]="mcx5"
+# Mellanox MT28908 Family [ConnectX-6]
+NIC_MODELS["15b3:101b"]="mcx6"
+
+# Intel Corporation Ethernet Controller X710 for 10GbE SFP+
+NIC_MODELS["8086:1572"]="x710"
+# Intel Corporation Device [8086:159b] (rev 02)
+NIC_MODELS["8086:159b"]="e810"
+
 #######################################
 # Export varibale with NIC model by the provided Vendor/Device IDs.
 # Globals:


### PR DESCRIPTION
The sapi-ts, in general, can be run on network adapters from various manufacturers.

Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Acked-by: Andrew Rybchenko <andrew.rybchenko@oktetlabs.ru>

------------
Testing done: the following command line still works:
```shell
./run.sh -n --cfg=<my-cfg> --ool=socket_cache --ool=onload \
--tester-run=sockapi-ts/level5/fd_caching/fd_cache_nonblock_sync:env=VAR.env.peer2peer_two_iut,use_libc=TRUE,check_first=FALSE,nonblock_first=TRUE,nonblock_func=fcntl,func=read
```