### PR TITLE
net-drv-ts fixes and sapi-ts update

### DIFF
--- a/cs/inc.conf_delay.yml
+++ b/cs/inc.conf_delay.yml
@@ -31,3 +31,7 @@
       value: "/agent/interface/xdp"
     - oid: "/conf_delay:xdp/ta:"
       value: 500
+    - oid: "/conf_delay:promisc"
+      value: "/agent/interface/promisc"
+    - oid: "/conf_delay:promisc/ta:"
+      value: 1000

--- a/cs/inc.iut_vm.yml
+++ b/cs/inc.iut_vm.yml
@@ -18,6 +18,13 @@
           - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/mem:/prealloc:"
             value: 1
 
+- cond:
+    if: ${TE_LOG_LISTENER_NETCONSOLE_IUT} != ""
+    then:
+      - set:
+          - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/serial:"
+            value: "udp:${TE_LOG_LISTENER}:${TE_LOG_LISTENER_NETCONSOLE_PORT_IUT}"
+
 - set:
     - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/cpu:/num:"
       value: "2"

--- a/cs/inc.log_listener.yml
+++ b/cs/inc.log_listener.yml
@@ -130,7 +130,7 @@
 # (for non-HWSIM hosts only)
 #
 - cond:
-    if: ${TE_LOG_LISTENER_NETCONSOLE_IUT} != "" & ${HWSIM} = ""
+    if: ${TE_LOG_LISTENER_NETCONSOLE_IUT} != "" & ${HWSIM} = "" & ${TE_VM2VM} = "" & ${TE_IUT_VM} = ""
     then:
       # Allocate UDP port to be used as netconsole local port
       - set:
@@ -150,7 +150,7 @@
 # (for non-HWSIM hosts only)
 #
 - cond:
-    if: ${TE_LOG_LISTENER_NETCONSOLE_TST1} != "" & ${HWSIM} = ""
+    if: ${TE_LOG_LISTENER_NETCONSOLE_TST1} != "" & ${HWSIM} = "" & ${TE_VM2VM} = ""
     then:
       # Allocate UDP port to be used as netconsole local port
       - set:

--- a/cs/inc.socktest.l5-unix.yml
+++ b/cs/inc.socktest.l5-unix.yml
@@ -349,6 +349,12 @@
     - oid: "/local:${TE_IUT_TA_NAME_NS}/env:EF_AF_XDP_ZEROCOPY"
       value: "${EF_AF_XDP_ZEROCOPY}"
 
+    - oid: "/local:${TE_IUT_TA_NAME_NS}/env:EF_AF_XDP_TX_KICK_START"
+      value: "${EF_AF_XDP_TX_KICK_START}"
+
+    - oid: "/local:${TE_IUT_TA_NAME_NS}/env:EF_AF_XDP_TX_KICK_BATCH"
+      value: "${EF_AF_XDP_TX_KICK_BATCH}"
+
     # Clustering
     - oid: "/local:${TE_IUT_TA_NAME_NS}/env:EF_CLUSTER_SIZE"
       value: "${EF_CLUSTER_SIZE}"

--- a/cs/inc.socktest.sfc_resource_mod_params.yml
+++ b/cs/inc.socktest.sfc_resource_mod_params.yml
@@ -16,3 +16,6 @@
     - if: ${SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS} != ""
       oid: "/agent:${TE_IUT_TA_NAME}/module:sfc_resource/parameter:enable_af_xdp_flow_filters"
       value: "${SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS}"
+    - if: ${SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS} != ""
+      oid: "/agent:${TE_IUT_TA_NAME}/module:sfc_resource/parameter:enable_af_xdp_5tuple_filters"
+      value: "${SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS}"

--- a/cs/inc.socktest.sfc_resource_mod_params.yml
+++ b/cs/inc.socktest.sfc_resource_mod_params.yml
@@ -16,6 +16,10 @@
     - if: ${SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS} != ""
       oid: "/agent:${TE_IUT_TA_NAME}/module:sfc_resource/parameter:enable_af_xdp_flow_filters"
       value: "${SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS}"
+      # The enable_af_xdp_5tuple_filters parameter can be set only if AF_XDP
+      # device is unregisted. Otherwise its setting fails with EBUSY.
+      # We leave it here considering that required value has already been set
+      # before.
     - if: ${SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS} != ""
       oid: "/agent:${TE_IUT_TA_NAME}/module:sfc_resource/parameter:enable_af_xdp_5tuple_filters"
       value: "${SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS}"

--- a/cs/inc.vm2vm.yml
+++ b/cs/inc.vm2vm.yml
@@ -19,6 +19,13 @@
           - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/mem:/prealloc:"
             value: 1
 
+- cond:
+    if: ${TE_LOG_LISTENER_NETCONSOLE_IUT} != ""
+    then:
+      - set:
+          - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/serial:"
+            value: "udp:${TE_LOG_LISTENER}:${TE_LOG_LISTENER_NETCONSOLE_PORT_IUT}"
+
 - set:
     - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:iut_vm/mgmt_net_device:"
       value: "e1000e"
@@ -61,6 +68,13 @@
             value: /dev/hugepages
           - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:tst_vm/mem:/prealloc:"
             value: 1
+
+- cond:
+    if: ${TE_LOG_LISTENER_NETCONSOLE_TST1} != ""
+    then:
+      - set:
+          - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:tst_vm/serial:"
+            value: "udp:${TE_LOG_LISTENER}:${TE_LOG_LISTENER_NETCONSOLE_PORT_TST1}"
 
 - set:
     - oid: "/agent:${TE_HYPERVISOR_TA_NAME}/vm:tst_vm/mgmt_net_device:"

--- a/cs/socktest.yml
+++ b/cs/socktest.yml
@@ -35,6 +35,7 @@
     - cm_tc.yml
     - cm_aggregation.yml
     - cm_l4_port.yml
+    - cm_keys.yml
 
 - cond:
     if: ${TE_LOG_LISTENER} != ""

--- a/dut/x710
+++ b/dut/x710
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 OKTET Labs Ltd. All rights reserved.
+
+# OL-Redmine-Id 11976: i40e does not support different types of filters
+# simultaneously, so we always set only 3-tuples.
+export SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS=0

--- a/dut/x710
+++ b/dut/x710
@@ -4,3 +4,12 @@
 # OL-Redmine-Id 11976: i40e does not support different types of filters
 # simultaneously, so we always set only 3-tuples.
 export SFC_RESOURCE_ENABLE_AF_XDP_5TUPLE_FILTERS=0
+
+# Set oof_shared_keep_thresh=0 to keep using a wild
+# filter for passively accepted TCP sockets.
+# See bug 11976 and README_AF_XDP.md in Onload tree.
+export ONLOAD_OOF_SHARED_KEEP_THRESH=0
+
+# Disable tests which use 5-tuple filters
+# See bug 11976 and README_AF_XDP.md in Onload tree.
+TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!SO_REUSEADDR"

--- a/ool/af_xdp_common
+++ b/ool/af_xdp_common
@@ -3,10 +3,6 @@
 # This file is not intended for standalone use.
 # It should be included from other configuration files.
 
-# Set oof_shared_keep_thresh=0 to keep using a wild
-# filter for passively accepted TCP sockets.
-export ONLOAD_OOF_SHARED_KEEP_THRESH=0
-
 # AF_XDP doesn't work with enabled huge pages. ON-12249.
 export EF_USE_HUGE_PAGES=0
 
@@ -22,11 +18,6 @@ TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!ONLOAD_ZC_SEND_USER_BUF"
 
 # Multicast tests have problems with AF_XDP. ON-12484
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!MULTICAST_RECV"
-
-# AF_XDP-Onload allows to insert 2 duplicate filters,
-# and one of the sockets does not work properly.
-# So, SO_REUSEADDR should be disabled. ON-12491
-TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!SO_REUSEADDR"
 
 # PIO is not available in this mode. ON-12578.
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!SF_TEMPLATE_SEND"

--- a/ool/config/af_xdp_no_filters
+++ b/ool/config/af_xdp_no_filters
@@ -2,8 +2,7 @@
 # (c) Copyright 2006 - 2022 Xilinx, Inc. All rights reserved.
 # This config option MUST BE used with
 # single queue mode only.
-# Use rss_cpus=1 during loading drivers to configure
-# single queue mode.
+# Set combined channels to 1 on tested interfaces before registering them.
 
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --script=ool/af_xdp_common"
 
@@ -14,8 +13,8 @@ TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!FORK"
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!NO_REUSE_STACK"
 
 
-TE_EXTRA_OPTS="$TE_EXTRA_OPTS --trc-tag=af_xdp_single"
+TE_EXTRA_OPTS="$TE_EXTRA_OPTS --trc-tag=af_xdp_no_filters"
 
-# We should set module option enable_af_xdp_flow_filters to 0 in af_xdp_single
-# mode. See ON-13897.
+# We should set module option enable_af_xdp_flow_filters to 0
+# in af_xdp_no_filters mode. See ON-13897.
 export SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS=0

--- a/ool/config/af_xdp_single
+++ b/ool/config/af_xdp_single
@@ -16,9 +16,6 @@ TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!NO_REUSE_STACK"
 
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --trc-tag=af_xdp_single"
 
-# Exclude AF_XDP single queue incompatible tests.
-TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!NO_AF_XDP_SINGLE"
-
 # We should set module option enable_af_xdp_flow_filters to 0 in af_xdp_single
 # mode. See ON-13897.
 export SFC_RESOURCE_ENABLE_AF_XDP_FLOW_FILTERS=0

--- a/ool/config/defaults
+++ b/ool/config/defaults
@@ -1,33 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # (c) Copyright 2006 - 2022 Xilinx, Inc. All rights reserved.
-SSH="ssh -qxTn -o BatchMode=yes"
-stdump="$SFC_ONLOAD_GNU/tools/ip/onload_stackdump"
-
-# Include the file if it really exists - this allows TS not to break.
-# It seems that the following functions may become unavailable on some
-# TE_TS_RIGSDIR implementations: 'get_te_iut_host'.
-if [[ -r "${TE_TS_RIGSDIR}/scripts/lib.run" ]] ; then
-    . ${TE_TS_RIGSDIR}/scripts/lib.run
-fi
-te_iut_host="$(get_te_iut_host)"
-
-find_default() {
-    name="$1"
-    defs="${@:2}"
-    echo $defs | sed "s/.*${name}[^.]*default: \([0-9]*\) .*/\1/"
-}
-
-if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
-    onload_defs=$($SSH $te_iut_host $stdump doc)
-else
-    stdump_remote="/tmp/onload_stackdump"
-    scp "${stdump}" "${te_iut_host}:${stdump_remote}" 1>/dev/null
-    onload_defs=$($SSH $te_iut_host $stdump_remote doc)
-    $SSH ${te_iut_host} "rm -f $stdump_remote"
-fi
 
 if [ -z $EF_TCP_URG_MODE ] ; then
-    val=$(find_default "EF_TCP_URG_MODE" $onload_defs)
+    val=$(find_ef_default "EF_TCP_URG_MODE")
     if test $val -eq 0 ; then
         TE_EXTRA_OPTS="$TE_EXTRA_OPTS --script=ool/config/urg_allow"
     else

--- a/ool/config/scooby
+++ b/ool/config/scooby
@@ -27,3 +27,7 @@ TE_EXTRA_OPTS="$TE_EXTRA_OPTS --trc-tag=scooby"
 # PIO is not available in this mode
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --tester-req=!SF_TEMPLATE_SEND"
 
+# nginx-like-st profile sets EF_AF_XDP_TX_KICK_BATCH=64 which is too high for
+# some tests e.g. performance/sfnt_pingpong. So we use the default value in
+# scooby mode. See bug 12309.
+export EF_AF_XDP_TX_KICK_BATCH=$(find_ef_default "EF_AF_XDP_TX_KICK_BATCH")

--- a/ool/config/zc_af_xdp
+++ b/ool/config/zc_af_xdp
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # (c) Copyright 2006 - 2022 Xilinx, Inc. All rights reserved.
 # This file is not intended for standalone use.
-# It should be used with af_xdp or af_xdp_single options
+# It should be used with af_xdp or af_xdp_no_filters options
 # to test AF_XDP in the ZC mode.
 
 export EF_AF_XDP_ZEROCOPY=1

--- a/ool/profile
+++ b/ool/profile
@@ -3,9 +3,17 @@
 
 # onload_set() and onload_import() are normally defined in the "onload"
 # scripts, and these functions are in use for the profile scripts.
+# Mimic the original Onload onload_set() default behaviour - do not set
+# the variable if it is already set by user.
 function onload_set()
 {
-  eval export $1=$2
+  var=$1
+  val=$2
+  if [ -z "${!var}" ] ; then
+    export $var=$val
+  else
+    echo "onload_set: $var=$val IGNORED (${!var})" >&2
+  fi
 }
 function onload_import()
 {

--- a/scripts/handle_dut
+++ b/scripts/handle_dut
@@ -23,6 +23,10 @@ case "$TE_ENV_IUT_DUT" in
     x3)
         TE_EXTRA_OPTS+=" --script=dut/x3"
         ;;
+    x710)
+        TE_EXTRA_OPTS+=" --script=dut/x710"
+        TE_EXTRA_OPTS+=" --script=dut/nonsf"
+        ;;
     *)
         TE_EXTRA_OPTS+=" --script=dut/nonsf"
         ;;

--- a/scripts/l5_run
+++ b/scripts/l5_run
@@ -15,6 +15,31 @@ if [[ -r "${TE_TS_RIGSDIR}/scripts/lib.run" ]] ; then
 fi
 te_iut_host="$(get_te_iut_host)"
 
+stdump="$SFC_ONLOAD_GNU/tools/ip/onload_stackdump"
+if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
+    ONLOAD_EF_DEFS=$($SSH $te_iut_host $stdump doc)
+else
+    stdump_remote="/tmp/onload_stackdump"
+    scp "${stdump}" "${te_iut_host}:${stdump_remote}" 1>/dev/null
+    ONLOAD_EF_DEFS=$($SSH $te_iut_host $stdump_remote doc)
+    $SSH ${te_iut_host} "rm -f $stdump_remote"
+fi
+export ONLOAD_EF_DEFS
+
+#######################################
+# Get default EF_* variable value.
+# Arguments:
+#   Variable name
+# Globals:
+#   ONLOAD_EF_DEFS
+# Outputs:
+#   Writes variable value to stdout
+#######################################
+find_ef_default() {
+    name="$1"
+    echo $ONLOAD_EF_DEFS | sed "s/.*${name}[^.]*default: \([0-9]*\) .*/\1/"
+}
+
 # Determining whether Onload was compiled with NDEBUG=1.
 # In this case ool_ndebug tag is added.
 if test "x${SFC_ONLOAD_LOCAL}" == "xyes" ; then

--- a/scripts/l5_run
+++ b/scripts/l5_run
@@ -48,10 +48,17 @@ else
     scp "${SFC_ONLOAD_GNU}/lib/transport/unix/libcitransport0.so" "${te_iut_host}:/tmp/libte-iut.so" 1>/dev/null
     LIB_PATH="/tmp/libte-iut.so"
 fi
-ssh "${te_iut_host}" "$LIB_PATH" | grep "(debug)" 1>/dev/null
-if test $? -ne 0 ; then
-    TE_EXTRA_OPTS="${TE_EXTRA_OPTS} --trc-tag=ool_ndebug --tester-req=!NO_NDEBUG"
-    export SFC_NDEBUG=1
+libinfo="$(${SSH} ${te_iut_host} "${LIB_PATH} 2>&1")"
+rc=$?
+if test $rc -ne 0 ; then
+    fail "${LIB_PATH} returned unexepected code: $rc"
+else
+    if [[ "$libinfo" == *\(release\)* ]] ; then
+        TE_EXTRA_OPTS+=" --trc-tag=ool_ndebug --tester-req=!NO_NDEBUG"
+        export SFC_NDEBUG=1
+    elif [[ "$libinfo" != *\(debug\)* ]] ; then
+        fail "cannot obtain type of build from the output: $libinfo"
+    fi
 fi
 if test "x${SFC_ONLOAD_LOCAL}" != "xyes" ; then
     ssh ${te_iut_host} "sudo rm /tmp/libte-iut.so"

--- a/scripts/virtio_virtio
+++ b/scripts/virtio_virtio
@@ -92,3 +92,19 @@ export TE_ENV_TST_DPDK_DRIVER="${TE_ENV_TST_DPDK_DRIVER:-uio_pci_generic}"
 export TE_IP4_POOL=192.168.1
 export TE_IP6_POOL=fec0:1:1:
 export TE_IP6_ALIEN=fec1:1:1::5555
+
+# Use hypervisor as a log listner by default
+if test -z "${TE_LOG_LISTENER}" -a -z "${TE_LOG_LISTENER_LOCALHOST}" ; then
+    test -z "${TE_HYPERVISOR}" \
+        || export TE_LOG_LISTENER="${TE_HYPERVISOR}"
+    test -z "${TE_HYPERVISOR_LOCALHOST}" \
+        || export TE_LOG_LISTENER_LOCALHOST="${TE_HYPERVISOR_LOCALHOST}"
+    test -z "${TE_HYPERVISOR_SSH_KEY}" \
+        || export TE_LOG_LISTENER_SSH_KEY="${TE_HYPERVISOR_SSH_KEY}"
+    test -z "${TE_HYPERVISOR_SSH_PORT}" \
+        || export TE_LOG_LISTENER_SSH_PORT="${TE_HYPERVISOR_SSH_PORT}"
+    test -z "${TE_HYPERVISOR_SSH_USER}" \
+        || export TE_LOG_LISTENER_SSH_USER="${TE_HYPERVISOR_SSH_USER}"
+fi
+export TE_LOG_LISTENER_NETCONSOLE_IUT=yes
+export TE_LOG_LISTENER_NETCONSOLE_TST1=yes


### PR DESCRIPTION
net-drv-ts regressions checked and logs are available at:
https://ts-factory.io/bublik/v2/runs/181336 - sfc Linux kernel upstream driver without RESET testing which kills the host
https://ts-factory.io/bublik/v2/runs/180868 - Intel X710 (0 unexpected results)
https://ts-factory.io/bublik/v2/runs/181744 - Virtio net on dynamic VM-to-VM (0 unexpected results)