### PR TITLE
dut/virtio_net: introduce new device under test

### DIFF
--- a/dut/virtio_net
+++ b/dut/virtio_net
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 OKTET Labs Ltd. All rights reserved.
+
+# VMs are not always configured to work properly without the default route
+# (which may be needed to access such resources as ldap, kerberos, nis or nfs).
+# Disable all such tests to avoid unpleasant results.
+TE_EXTRA_OPTS+=" --tester-req=!CHANGE_DEFAULT_ROUTE"
+
+# Do not run performance tests on VMs.
+TE_EXTRA_OPTS+=" --tester-req=!PERF"
+
+# Tests which consume a lot of memory usually invoke oom-killer on VMs.
+TE_EXTRA_OPTS+=" --tester-req=!MEMORY_HOG"

--- a/scripts/handle_dut
+++ b/scripts/handle_dut
@@ -27,6 +27,10 @@ case "$TE_ENV_IUT_DUT" in
         TE_EXTRA_OPTS+=" --script=dut/x710"
         TE_EXTRA_OPTS+=" --script=dut/nonsf"
         ;;
+    virtio_net)
+        TE_EXTRA_OPTS+=" --script=dut/virtio_net"
+        TE_EXTRA_OPTS+=" --script=dut/nonsf"
+        ;;
     *)
         TE_EXTRA_OPTS+=" --script=dut/nonsf"
         ;;

--- a/scripts/nic-pci2dut
+++ b/scripts/nic-pci2dut
@@ -22,6 +22,9 @@ NIC_MODELS["8086:1572"]="x710"
 # Intel Corporation Device [8086:159b] (rev 02)
 NIC_MODELS["8086:159b"]="e810"
 
+# Red Hat, Inc. Virtio network device
+NIC_MODELS["1af4:1000"]="virtio_net"
+
 #######################################
 # Export varibale with NIC model by the provided Vendor/Device IDs.
 # Globals:


### PR DESCRIPTION
The virtio driver implies working in a virtual machine. And in this case, it does not make sense to run performance tests, as well as tests that require a lot of RAM and tests that change the default route.

Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

-----
testing done:
Run the following command on VM: `./run.sh -q --cfg=<my-vm> --tester-run=sockapi-ts/usecases/send_recv`
... and view the following entries in the log: `--tester-req=!CHANGE_DEFAULT_ROUTE --tester-req=!PERF --tester-req=!MEMORY_HOG`