### PR TITLE
scripts: ignore tests not suitable for configuration

### DIFF
--- a/scripts/detect_num_testers
+++ b/scripts/detect_num_testers
@@ -8,6 +8,13 @@ if [[ -z "$TE_TST2" ]] ; then
     TE_EXTRA_OPTS+=" --opts=opts/one_tester"
 else
     TE_EXTRA_OPTS+=" --opts=opts/two_testers"
+    # The test suite can run tests where the IUT NIC being tested
+    # is connected to both TST1 and TST2 hosts.
+    # The tester requirement ENV-2PEERS-IUT is responsible for this.
+    if [[ "$TE_PCI_VENDOR_IUT_TST1" != "$TE_PCI_VENDOR_IUT_TST2" \
+            || "$TE_PCI_DEVICE_IUT_TST1" != "$TE_PCI_DEVICE_IUT_TST2" ]] ; then
+        TE_EXTRA_OPTS+=" --tester-req=!ENV-2PEERS-IUT"
+    fi
 fi
 
 # The remaining 'opts/*' files are added from 'scripts/iut_os',


### PR DESCRIPTION
The test suite can run tests where the IUT NIC being tested is connected to both TST1 and TST2 hosts. Obviously, the configuration must meet these conditions.

OL-Redmine-Id: 12265
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

------
Testing done: checked with the following command line (no tests to run):
```shell
./run.sh -n --cfg=<my-cfg> --tester-run=sockapi-ts/udp/recv_from_multiple_sources_two_ifs:env=VAR.env.two_nets.iut_both,peers_num=10,max_data_len=1400,recv_func=recv
```