### PR TITLE
scripts: handle TRC tags for linux-6

### DIFF
--- a/scripts/iut_os
+++ b/scripts/iut_os
@@ -197,6 +197,23 @@ if test \( -n "${TE_IUT}" -o "${TE_IUT_BUILD}" = local \) -a -z "${TE_IUT_TA_TYP
                     TE_EXTRA_OPTS="${TE_EXTRA_OPTS} --trc-tag=linux-5:$SECOND_NUMBER"
                     TE_EXTRA_OPTS="${TE_EXTRA_OPTS} --trc-tag=linux:5"
                     ;;
+                # Last 5.0 kernel is 5.19, so for 6.X linux-5 is equal
+                # to X + 20.
+                # Last 4.0 kernel is 4.20, so for 5.X linux-4 is equal
+                # to X + 21 (for linux-6 is X + 21 + 20).
+                # Last 3.0 kernel is 3.19, so for 4.X linux-3 is equal
+                # to X + 20 (for linux-6 is X + 20 + 21 + 20).
+                # Last 2.6.* kernel is 2.6.39, so for 3.X linux-2.6 is
+                # equal to linux-3 + 40 (for linux-6: X + 40 + 20 + 21 + 20).
+                6.* )
+                    SECOND_NUMBER=$(echo ${kernel_version} | sed "s/6\.\([0-9]*\)[.-].*/\1/")
+                    TE_EXTRA_OPTS+=" --trc-tag=linux-2.6:$((SECOND_NUMBER + 40 + 20 + 21 + 20))"
+                    TE_EXTRA_OPTS+=" --trc-tag=linux-3:$((SECOND_NUMBER + 20 + 21 + 20))"
+                    TE_EXTRA_OPTS+=" --trc-tag=linux-4:$((SECOND_NUMBER + 21 + 20))"
+                    TE_EXTRA_OPTS+=" --trc-tag=linux-5:$((SECOND_NUMBER + 20))"
+                    TE_EXTRA_OPTS+=" --trc-tag=linux-6:$SECOND_NUMBER"
+                    TE_EXTRA_OPTS+=" --trc-tag=linux:6"
+                    ;;
                 * )
                     # the kernel is not 2.6 or 3
                     ;;


### PR DESCRIPTION

OL-Redmine-Id: 12560
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---------
The test is green now on Linux 6.0.5-200.fc36.x86_64:
```shell
./run.sh -n --cfg=farin-sfc --ool=onload --tester-run=sockapi-ts/level5/interop/fcntl_nonblock:change_iut=FALSE,child_sys_call=FALSE,env=VAR.env.peer2peer,fcntl_sys_call=TRUE,func=read,is_pipe=FALSE,iut_sys_call=FALSE,nonblock_func=socket,sock_type=SOCK_STREAM,start_blocking=FALSE 
```
... and log.txt shows now these TRC tags:
```
RING  Dispatcher  TRC tags  16:26:52.950
 linux-6.0.5-200.fc36.x86_64 linux-6.0.5-200.fc36 linux-6.0.5-200 linux-6.0.5 linux-6.0 linux-6 linux:2 ul-64 
kernel-64 libc:35 linux-2.6:101 linux-3:61 linux-4:41 linux-5:20 linux-6:0 linux:6 linux-headers:600 ool_epoll:1 
l5-nic v5 v5:1 no-aio no-aio-dgram no_hw_tx_mcast_loop fw_low reuse_pco ool_loop:0 
ool_loop_linux cplane_log_to_kernel urg_ignore
```