### PR TITLE
Update ts-conf required for new test in net-drv-ts to check Rx rules

### DIFF
--- a/cs/net-drv-ts.yml
+++ b/cs/net-drv-ts.yml
@@ -17,6 +17,7 @@
     - cm_ntpd.yml
     - cm_bpf.yml
     - cm_rss.yml
+    - cm_rx_rules.yml
 
 - include:
     - inc.conf_delay.yml


### PR DESCRIPTION
cs: register Rx rules objects for net-drv-ts

Net driver test suite is going to test Rx classification rules.

OL-Redmine-Id: 11880
Signed-off-by: Dmitry Izbitsky <dmitry.izbitsky@oktetlabs.ru>
Reviewed-by: Andrew Rybchenko <andrew.rybchenko@oktetlabs.ru>