### PR TITLE
scripts/handle_dut: disable tests incompatible with DUT

### DIFF
--- a/scripts/handle_dut
+++ b/scripts/handle_dut
@@ -39,3 +39,8 @@ esac
 case "$TE_ENV_TST1_DUT" in
     ef100) TE_EXTRA_OPTS+=" --script=dut/ef100_tst" ;;
 esac
+
+if [[ -z "$TE_IUT_TST1_IUT" ]] ; then
+    # Disable tests that require two links on DUT
+    TE_EXTRA_OPTS+=" --tester-req=!ENV-2LINKS-IUT"
+fi


### PR DESCRIPTION
Do not run tests that require two DUT links, and only one is available.

OL-Redmine-Id: 12265
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

-----
Testing done with the following command line (that runs nothing now on my-cfg with one DUT interface):
```shell
./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/route/rt_if_by_dst_dr:env=VAR.env.route_two_iut_ifs
```