### PR TITLE
ool/config: check conditions to run af_xdp without filters

### DIFF
--- a/ool/config/af_xdp_no_filters
+++ b/ool/config/af_xdp_no_filters
@@ -4,6 +4,43 @@
 # single queue mode only.
 # Set combined channels to 1 on tested interfaces before registering them.
 
+#######################################
+# Checks the combined channels number is equal one on the aim interface.
+# Arguments:
+#   host       - host name
+#   interface  - name of interface registered in Onload
+# Outputs:
+#   Writes a message to stderr if combined channels number is not equal one
+#######################################
+check_combined_channels_num() {
+    local host="$1" ; shift
+    local interface="$1" ; shift
+    local combined
+
+    combined="$(set -o pipefail ; \
+             ${SSH} "${host}" "/sbin/ethtool -l "${interface}"" | \
+             awk '/Current hardware settings/ {seen = 1} seen {print}' | \
+             awk '/Combined/{print $2}')"
+
+    if (( $? != 0 )); then
+        echo -e "WARNING: unable to retrieve combined channels number" \
+                "on ${host}'s ${interface}.\nEnsure that the interface is" \
+                "registered with only one combined queue."
+        return 0
+    fi
+
+    if [[ "${combined}" != "1" ]] ; then
+        echo "ERROR: inappropriate combined channels number on" \
+             "${host}'s ${interface} (${combined} instead of 1)." >&2
+        exit 1
+    fi
+}
+
+check_combined_channels_num "${TE_IUT}" "${TE_ORIG_IUT_TST1}"
+if [[ -n "${TE_ORIG_IUT_TST1_IUT}" ]]; then
+    check_combined_channels_num "${TE_IUT}" "${TE_ORIG_IUT_TST1_IUT}"
+fi
+
 TE_EXTRA_OPTS="$TE_EXTRA_OPTS --script=ool/af_xdp_common"
 
 # Multiple stacks are not supported with single queue mode as


### PR DESCRIPTION
af_xdp_no_filetrs should be tested using the interface that is configured with a single combined channel, because multiple channels without set flow filter may lead the af_xdp socket get only part of the trafic. To avoid such misconfigured test cases, we check the number of combined channels on the aim interface and exit with failure if the number is not equal one.

OL-Redmine-Id: 12237
Signed-off-by: Pavel Liulchak <pavel.liulchak@oktetlabs.ru>
Acked-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

___________________________
Testing done with the same cmd line but with different combined channels values:
1) ___
```
$sudo ethtool -l $TE_IUT_TST1
Channel parameters for $TE_IUT_TST1:
...
Current hardware settings:
RX:             n/a
TX:             n/a
Other:          n/a
Combined:       4
```
./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --ool=af_xdp_no_filters --ool=onload --log-html=html
```
logs:
TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=$TE_IUT_TST1_IUT
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=$TE_TST1_IUT_IUT
WARNING! SFC_ONLOAD_SFPTPD is empty. Timestamps testing won't be enabled.
TCP/Ceph is not supported
~/dev/onload/sapi-ts/talib_sockapi_ts ~/dev/onload/sapi-ts
~/dev/onload/sapi-ts
ERROR: inappropriate combined channels number on my-cfg's TE_IUT_TST1 (4 instead of 1).
```
2) ___
```
$ sudo ethtool -l $TE_IUT_TST1
Channel parameters for $TE_IUT_TST1:
...
Current hardware settings:
RX:             n/a
TX:             n/a
Other:          n/a
Combined:       1

$ sudo ethtool -l $TE_IUT_TST1_IUT
Channel parameters for $TE_IUT_TST1_IUT:
Pre-set maximums:
...
Current hardware settings:
RX:             n/a
TX:             n/a
Other:          n/a
Combined:       2
```
./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --ool=af_xdp_no_filters --ool=onload --log-html=html
```
logs:
TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=$TE_IUT_TST1_IUT
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=$TE_TST1_IUT_IUT
WARNING! SFC_ONLOAD_SFPTPD is empty. Timestamps testing won't be enabled.
TCP/Ceph is not supported
~/dev/onload/sapi-ts/talib_sockapi_ts ~/dev/onload/sapi-ts
~/dev/onload/sapi-ts
ERROR: inappropriate combined channels number on my-cfg's TE_IUT_TST1_IUT (2 instead of 1).
```
3) ____
interface that is not supporting `ethtool -l`
```
$ ethtool -l eth1
Channel parameters for eth1:
Cannot get device channel parameters
: Operation not supported

```
./run.sh -q --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --ool=af_xdp_no_filters --ool=onload --log-html=html
```
logs:
TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=
...
WARNING: unable to retrieve combined channels number on my-cfg's TE_IUT_TST1.
Ensure that the interface is registered with only one combined queue.
...
```
4) ____
```
$ sudo ethtool -l $TE_IUT_TST1
Channel parameters for $TE_IUT_TST1:
...
Current hardware settings:
RX:             n/a
TX:             n/a
Other:          n/a
Combined:       1

$ sudo ethtool -l $TE_IUT_TST1_IUT
Channel parameters for $TE_IUT_TST1_IUT:
Pre-set maximums:
...
Current hardware settings:
RX:             n/a
TX:             n/a
Other:          n/a
Combined:       1
```
Both interfaces are configured with single combined queue each.  Tests are passed.
./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --ool=af_xdp_no_filters --ool=onload --log-html=html
```
logs:
TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=$TE_IUT_TST1_IUT
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=$TE_TST1_IUT_IUT
WARNING! SFC_ONLOAD_SFPTPD is empty. Timestamps testing won't be enabled.
TCP/Ceph is not supported
~/dev/onload/sapi-ts/talib_sockapi_ts ~/dev/onload/sapi-ts
~/dev/onload/sapi-ts
--->>> Starting Logger...done
--->>> Starting RCF...done
--->>> Starting Configurator...done
--->>> Start Tester
Starting package sockapi-ts
...
Done package sockapi-ts pass
--->>> Shutdown Configurator...done
--->>> Flush Logs
--->>> Shutdown RCF...done
--->>> Shutdown Logger...done
--->>> Logs conversion...done

Run (total)                              32
  Passed, as expected                    32
  Failed, as expected                     0
  Passed unexpectedly                     0
  Failed unexpectedly                     0
  Aborted (no useful result)              0
  New (expected result is not known)      0
Not Run (total)                       10901
  Skipped, as expected                    0
  Skipped unexpectedly                    0
```