### PR TITLE
scripts/l5_run: fix getting default EF_* variable values

### DIFF
--- a/scripts/l5_run
+++ b/scripts/l5_run
@@ -37,7 +37,7 @@ export ONLOAD_EF_DEFS
 #######################################
 find_ef_default() {
     name="$1"
-    echo $ONLOAD_EF_DEFS | sed "s/.*${name}[^.]*default: \([0-9]*\) .*/\1/"
+    echo $ONLOAD_EF_DEFS | sed -n "s/.*${name}[^.]*default: \([0-9]*\) .*/\1/p"
 }
 
 # Determining whether Onload was compiled with NDEBUG=1.


### PR DESCRIPTION
Fix find_ef_default() function for the cases when we try to get the default value of non-existent variable.
Tell 'sed' to print only matched lines and omit all others. Otherwise, if there is no occurrences, it will print out all the input and put invalid data as a result.

OL-Redmine-Id: 12616
Fixes: 28e1f46bad27 ("ool/config: set EF variable to default value")
Signed-off-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---

**Testing**
Run sapi-ts with master Onload.
```
--tester-run=sockapi-ts/usecases/read_write --ool=onload --ool=scooby

# Output
...
--->>> Starting Logger...done
--->>> Starting RCF...done
--->>> Starting Configurator...done
--->>> Start Tester
Starting package sockapi-ts
Starting test prologue                                                                        pass
Starting package usecases
Starting test read_write                                                                      pass
Starting test read_write                                                                      pass
Starting test read_write                                                                      pass
Starting test read_write                                                                      pass
Starting test read_write                                                                      pass
Done package usecases pass
Starting test epilogue                                                                        pass
Done package sockapi-ts pass
--->>> Shutdown Configurator...done
--->>> Flush Logs
--->>> Shutdown RCF...done
--->>> Shutdown Logger...done
--->>> Logs conversion...done

Run (total)                               7
  Passed, as expected                     7
  Failed, as expected                     0
  Passed unexpectedly                     0
  Failed unexpectedly                     0
  Aborted (no useful result)              0
  New (expected result is not known)      0
Not Run (total)                       10897
  Skipped, as expected                    0
  Skipped unexpectedly                    0

```
