### PR TITLE
scripts: remove sudo when delete libte-iut.so

### DIFF
--- a/scripts/l5_run
+++ b/scripts/l5_run
@@ -61,7 +61,11 @@ else
     fi
 fi
 if test "x${SFC_ONLOAD_LOCAL}" != "xyes" ; then
-    ssh ${te_iut_host} "sudo rm /tmp/libte-iut.so"
+    ssh ${te_iut_host} "rm /tmp/libte-iut.so"
+
+    if [[ $? != 0 ]] ; then
+        fail "Unable to delete $LIB_PATH on ${te_iut_host} via ssh"
+    fi
 fi
 
 if test "$EF_IUT_EF10" = "true" ; then


### PR DESCRIPTION
Not all users may be permitted to launch commands via sudo without additional password verification. Lack of the permission may be a cause of appearance of unwanted messages about necessity to read the password by terminal. In l5_run script, we have removed sudo from the command deleting libte-iut.so library on iut host to prevent appearing of such redundant messages for users without the privilege.

OL-Redmine-Id: 12650
Signed-off-by: Pavel Liulchak <pavel.liulchak@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

--------------------------
Testing done:
1) before the patch:
`./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --log-html=html --ool=onload`

TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=$TE_IUT_TST1_IUT
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=$TE_TST1_IUT_IUT
WARNING! SFC_ONLOAD_SFPTPD is empty. Timestamps testing won't be enabled.
TCP/Ceph is not supported
~/dev/onload/sapi-ts/talib_sockapi_ts ~/dev/onload/sapi-ts
~/dev/onload/sapi-ts
**sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper**
**sudo: a password is required**
Exporting TE installation directory as TE_INSTALL:
    /home/pliulchak/dev/onload/sapi-ts/build/inst
Exporting path to host executables:
    /home/pliulchak/dev/onload/sapi-ts/build/inst/default/bin
Simple RCF consistency check succeeded
--->>> Starting Logger...done


2) after the patch (messages are disappeared):
`./run.sh -n --cfg=my-cfg --tester-run=sockapi-ts/usecases/send_recv --log-html=html --ool=onload`

TE_IUT_TST1=$TE_IUT_TST1
TE_IUT_TST1_IUT=$TE_IUT_TST1_IUT
TE_TST1_IUT=$TE_TST1_IUT
TE_TST1_IUT_IUT=$TE_TST1_IUT_IUT
WARNING! SFC_ONLOAD_SFPTPD is empty. Timestamps testing won't be enabled.
TCP/Ceph is not supported
~/dev/onload/sapi-ts/talib_sockapi_ts ~/dev/onload/sapi-ts
~/dev/onload/sapi-ts
Exporting TE installation directory as TE_INSTALL:
    /home/pliulchak/dev/onload/sapi-ts/build/inst
Exporting path to host executables:
    /home/pliulchak/dev/onload/sapi-ts/build/inst/default/bin
Simple RCF consistency check succeeded
--->>> Starting Logger...done