### PR TITLE
scripts/l5_run: update according to changes in onload

### DIFF
--- a/scripts/l5_run
+++ b/scripts/l5_run
@@ -69,10 +69,10 @@ if test "x${SFC_ONLOAD_LOCAL}" != "xyes" ; then
 fi
 
 if test "$EF_IUT_EF10" = "true" ; then
-    export IUT_TS_TX_TCP=0
+    export IUT_TS_TX_TCP=1
     export IUT_TS_RX_TCP=1
     export IUT_TS_SYS_ZERO=0
-    export IUT_TS_TX_SW=1
+    export IUT_TS_TX_SW=0
     export IUT_TS_TX_HW=1
     export IUT_TS_TX_SW_UDP=0
     export IUT_TS_TX_SCHED=0


### PR DESCRIPTION
TX TCP timestamps generation by Onload now occurs even without setting the ONLOAD_SOF_TIMESTAMPING_STREAM, so IUT_TS_TX_TCP variable ought to be 1. Additionally, Onload does not generate SW TX timestamps, therefore IUT_TS_TX_SW should be set to 0. The previous setting of 1 might have been an oversight, given that when IUT_TS_TX_TCP is zero, the timestamp package function ts_check_cmsghdr_addr() doesn't consider IUT_TS_TX_SW variable at all.

AMD-Jira-ID: ON-14925

Acked-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>