### PR TITLE
cs: turn on exception-trace

### DIFF
--- a/cs/inc.socktest.common.yml
+++ b/cs/inc.socktest.common.yml
@@ -187,3 +187,12 @@
 
 - include:
     - inc.socktest.congestion.yml
+
+- set:
+    - oid: "/agent:${TE_IUT_TA_NAME}/sys:/debug:/exception-trace:"
+      value: "1"
+    - oid: "/agent:${TE_TST1_TA_NAME}/sys:/debug:/exception-trace:"
+      value: "1"
+    - if: ${TE_TST2_TA_NAME} != ""
+      oid: "/agent:${TE_TST2_TA_NAME}/sys:/debug:/exception-trace:"
+      value: "1"


### PR DESCRIPTION
OL-Redmine-Id: 13023

Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

---

Some hosts may have unset exception tracing and that may complicate the work of serial console parser that expects specific message in the kernel logs. In this patch `/proc/sys/debug/exception-trace` value is set to 1 using the corresponding Configurator subtree.

Testing done:
Open TE: 5d4ca23a0ce5d2832b354e9965155b534fa99d72
Open Onload: 60f8b6910c26577d2ac3b9ff4c6770a330fabc3f

For testing purposes exception-trace was set from 1 to 0.

Reproducer: `./run.sh -q --cfg=${my_host} --tester-run=sockapi-ts/usecases/send_recv --ool=onload --log-html=html`

`cat /proc/sys/debug/exception-trace` output on `${my_host}`:
Before test run: `1`
While test run: `0`
