### PR TITLE
Enable support for NICs with multiple ports on a single PCI function

### DIFF
--- a/cs/inc.dpdk.yml
+++ b/cs/inc.dpdk.yml
@@ -118,10 +118,10 @@
       - add:
           - if: ${TE_PCI_INSTANCE_IUT_TST1} != ""
             oid: "/local:${TE_IUT_TA_NAME}/dpdk:/vdev:${TE_ENV_RTE_VDEV_NAME}/slave:${TE_PCI_INSTANCE_IUT_TST1}"
-            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1}"
+            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1}${TE_PCI_FN_NETDEV_IUT_TST1:+/netdev:${TE_PCI_FN_NETDEV_IUT_TST1}}"
           - if: ${TE_PCI_INSTANCE_IUT_TST1a} != ""
             oid: "/local:${TE_IUT_TA_NAME}/dpdk:/vdev:${TE_ENV_RTE_VDEV_NAME}/slave:${TE_PCI_INSTANCE_IUT_TST1a}"
-            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1a}"
+            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1a}${TE_PCI_FN_NETDEV_IUT_TST1a:+/netdev:${TE_PCI_FN_NETDEV_IUT_TST1a}}"
 
       - set:
           - if: ${TE_PCI_INSTANCE_IUT_TST1} != ""

--- a/cs/inc.net_cfg_pci_fns.yml
+++ b/cs/inc.net_cfg_pci_fns.yml
@@ -8,7 +8,7 @@
       - add:
           - oid: "/net:net1"
           - oid: "/net:net1/node:A"
-            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1}"
+            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1}${TE_PCI_FN_NETDEV_IUT_TST1:+/netdev:${TE_PCI_FN_NETDEV_IUT_TST1}}"
       - set:
           - oid: "/net:net1/node:A/type:"
             value: "1"
@@ -29,7 +29,7 @@
     then:
       - add:
           - oid: "/net:net1/node:B"
-            value: "/agent:${TE_TST1_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_TST1_IUT}/device:${TE_PCI_DEVICE_TST1_IUT}/instance:${TE_PCI_INSTANCE_TST1_IUT}"
+            value: "/agent:${TE_TST1_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_TST1_IUT}/device:${TE_PCI_DEVICE_TST1_IUT}/instance:${TE_PCI_INSTANCE_TST1_IUT}${TE_PCI_FN_NETDEV_TST1_IUT:+/netdev:${TE_PCI_FN_NETDEV_TST1_IUT}}"
       - set:
           - oid: "/net:net1/node:B/type:"
             value: "${TE_TST1_IS_IUT:-0}"
@@ -60,7 +60,7 @@
       - add:
           - oid: "/net:net1a"
           - oid: "/net:net1a/node:A"
-            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1a}"
+            value: "/agent:${TE_IUT_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_IUT_TST1}/device:${TE_PCI_DEVICE_IUT_TST1}/instance:${TE_PCI_INSTANCE_IUT_TST1a}${TE_PCI_FN_NETDEV_IUT_TST1a:+/netdev:${TE_PCI_FN_NETDEV_IUT_TST1a}}"
       - set:
           - oid: "/net:net1a/node:A/type:"
             value: "1"
@@ -81,7 +81,7 @@
     then:
       - add:
           - oid: "/net:net1a/node:B"
-            value: "/agent:${TE_TST1_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_TST1_IUT}/device:${TE_PCI_DEVICE_TST1_IUT}/instance:${TE_PCI_INSTANCE_TST1a_IUT}"
+            value: "/agent:${TE_TST1_TA_NAME}/hardware:/pci:/vendor:${TE_PCI_VENDOR_TST1_IUT}/device:${TE_PCI_DEVICE_TST1_IUT}/instance:${TE_PCI_INSTANCE_TST1a_IUT}${TE_PCI_FN_NETDEV_TST1a_IUT:+/netdev:${TE_PCI_FN_NETDEV_TST1a_IUT}}"
       - set:
           - oid: "/net:net1a/node:B/type:"
             value: "${TE_TST1_IS_IUT:-0}"

--- a/scripts/export_ifnames
+++ b/scripts/export_ifnames
@@ -6,5 +6,6 @@
 
 # Do not export interfaces in case of build only
 if [[ "$TE_TS_BUILD_ONLY" != "yes" ]] ; then
+    source "${SF_TS_CONFDIR}/make_cmds"
     export_ifnames
 fi

--- a/scripts/lib
+++ b/scripts/lib
@@ -130,6 +130,47 @@ get_ifnames_by_driver() {
 }
 
 #######################################
+# Get interface name on host by vendor/pci IDs and instance number.
+# It is assumed that the driver is loaded.
+# Arguments:
+#   Host name
+#   Vendor Id
+#   Device Id
+#   Instance number
+# Outputs:
+#   Writes interface name to stdout
+#######################################
+get_iface_by_vendor() {
+    local host=$1 ; shift
+    local vid=$1 ; shift
+    local did=$1 ; shift
+    local inst_num=$1 ; shift
+
+    local to_find="PCI_ID=${vid}:${did}"
+    to_find="${to_find^^}"
+
+    # virtio-pci stores the 'net' directory inside 'virtioN'
+    local cmd="
+        num=0
+        for d in /sys/bus/pci/devices/*; do
+            if grep -q ${to_find} \$d/uevent 2>/dev/null; then
+                dirname="\${d}/net"
+                altdir="\${d}/virtio*"
+                if ! test -d "\${dirname}" && test -d "\$altdir" ; then
+                    dirname="\${altdir}/net"
+                fi
+                if test \$num -eq $inst_num ; then
+                    ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2
+                    break
+                fi
+                num=$((num + 1))
+            fi
+        done
+    "
+    $SSH $host "$cmd"
+}
+
+#######################################
 # Get interface names on host by vendor/pci IDs and instance number.
 # It is assumed that the driver is loaded.
 # Arguments:
@@ -148,26 +189,8 @@ get_ifnames_by_vendor() {
     local inst1_num=$1 ; shift
     local inst2_num=$1
 
-    local to_find="PCI_ID=${vid}:${did}"
-    to_find="${to_find^^}"
-
-    # virtio-pci stores the 'net' directory inside 'virtioN'
-    local cmd="
-        for d in /sys/bus/pci/devices/*; do
-            if grep -q ${to_find} \$d/uevent 2>/dev/null; then
-                dirname="\${d}/net"
-                altdir="\${d}/virtio*"
-                if ! test -d "\${dirname}" && test -d "\$altdir" ; then
-                    dirname="\${altdir}/net"
-                fi
-                ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2
-            fi
-        done
-    "
-    local ifs=($($SSH $host "$cmd"))
-
-    echo "${ifs[$inst1_num]}"
-    [[ -z "$inst2_num" ]] || echo "${ifs[$inst2_num]}"
+    get_iface_by_vendor "$host" "$vid" "$did" "$inst1_num"
+    [[ -z "$inst2_num" ]] || get_iface_by_vendor "$host" "$vid" "$did" "$inst2_num"
 }
 
 #######################################

--- a/scripts/lib
+++ b/scripts/lib
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # (c) Copyright 2006 - 2022 Xilinx, Inc. All rights reserved.
+#
+# Note: the script uses functions and variables declared in the make_cmds file,
+# therefore, the make_cmds file must be sourced before using the functions from
+# this script.
+
 export TE_LOG_LISTENER_LOG_LEVEL=WARN
 SOCKAPI_TS_IF_ALIAS_DONE=false
-
-[[ -n "$SSH" ]] || SSH="ssh -qxTn -o BatchMode=yes -o StrictHostKeyChecking=no"
 
 get_random_vlan()
 {
@@ -124,7 +127,8 @@ get_ifnames_by_driver() {
             fi;
         done
     "
-    local ifs=($($SSH $host "$cmd"))
+    make_cmds_for_host $host
+    local ifs=($(process_ssh_cmd "$cmd"))
 
     echo "${ifs[@]}"
 }
@@ -151,23 +155,24 @@ get_iface_by_vendor() {
 
     # virtio-pci stores the 'net' directory inside 'virtioN'
     local cmd="
-        num=0
+        num=0;
         for d in /sys/bus/pci/devices/*; do
             if grep -q ${to_find} \$d/uevent 2>/dev/null; then
-                dirname="\${d}/net"
-                altdir="\${d}/virtio*"
+                dirname="\${d}/net";
+                altdir="\${d}/virtio*";
                 if ! test -d "\${dirname}" && test -d "\$altdir" ; then
-                    dirname="\${altdir}/net"
-                fi
+                    dirname="\${altdir}/net";
+                fi;
                 if test \$num -eq $inst_num ; then
-                    ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2
-                    break
-                fi
-                num=$((num + 1))
-            fi
+                    ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2;
+                    break;
+                fi;
+                num=$((num + 1));
+            fi;
         done
     "
-    $SSH $host "$cmd"
+    make_cmds_for_host $host
+    process_ssh_cmd "$cmd"
 }
 
 #######################################
@@ -269,7 +274,8 @@ export_iut_fw_version() {
     local host="$1"
     local ifname="$2"
 
-    fw_version=$(${SSH} ${host} "sudo /sbin/ethtool -i $ifname 2>/dev/null | grep \"firmware-version\" | sed \"s/.*: //\"")
+    make_cmds_for_host $host
+    fw_version=$(process_ssh_cmd "sudo /sbin/ethtool -i $ifname 2>/dev/null | grep \"firmware-version\" | sed \"s/.*: //\"")
 
     export IUT_FW_VERSION="$fw_version"
 }

--- a/scripts/lib
+++ b/scripts/lib
@@ -156,10 +156,11 @@ get_ifnames_by_vendor() {
         for d in /sys/bus/pci/devices/*; do
             if grep -q ${to_find} \$d/uevent 2>/dev/null; then
                 dirname="\${d}/net"
-                if ! test -d "\${dirname}" ; then
-                    dirname="\${d}/virtio*/net"
+                altdir="\${d}/virtio*"
+                if ! test -d "\${dirname}" && test -d "\$altdir" ; then
+                    dirname="\${altdir}/net"
                 fi
-                ls \${dirname}
+                ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2
             fi
         done
     "

--- a/scripts/lib
+++ b/scripts/lib
@@ -141,6 +141,7 @@ get_ifnames_by_driver() {
 #   Vendor Id
 #   Device Id
 #   Instance number
+#   NetDev on the instance number (may be empty)
 # Outputs:
 #   Writes interface name to stdout
 #######################################
@@ -149,12 +150,17 @@ get_iface_by_vendor() {
     local vid=$1 ; shift
     local did=$1 ; shift
     local inst_num=$1 ; shift
+    local netdev_num=$1
 
     local to_find="PCI_ID=${vid}:${did}"
     to_find="${to_find^^}"
+    [[ -n "$netdev_num" ]] || netdev_num=0
+    # numbering starts with one in sed
+    local row=$((netdev_num + 1))
 
     # virtio-pci stores the 'net' directory inside 'virtioN'
     local cmd="
+        set -o pipefail;
         num=0;
         for d in /sys/bus/pci/devices/*; do
             if grep -q ${to_find} \$d/uevent 2>/dev/null; then
@@ -164,7 +170,8 @@ get_iface_by_vendor() {
                     dirname="\${altdir}/net";
                 fi;
                 if test \$num -eq $inst_num ; then
-                    ls \${dirname} || echo 'WARN: is the net driver loaded?' >&2;
+                    ls -1 \${dirname} | sed -n "${row}p"
+                       || echo 'WARN: is the net driver loaded on ${host}?' >&2;
                     break;
                 fi;
                 num=$((num + 1));
@@ -176,14 +183,17 @@ get_iface_by_vendor() {
 }
 
 #######################################
-# Get interface names on host by vendor/pci IDs and instance number.
+# Get interface names on host by vendor/pci IDs and instance number with
+# netdev number.
 # It is assumed that the driver is loaded.
 # Arguments:
 #   Host name
 #   Vendor Id
 #   Device Id
 #   First instance number
+#   NetDev on the first instance number (may be empty)
 #   Second instance number (may be empty)
+#   NetDev on the second instance number (may be empty)
 # Outputs:
 #   Writes interface names to stdout
 #######################################
@@ -192,10 +202,13 @@ get_ifnames_by_vendor() {
     local vid=$1 ; shift
     local did=$1 ; shift
     local inst1_num=$1 ; shift
-    local inst2_num=$1
+    local netdev1_num=$1 ; shift
+    local inst2_num=$1 ; shift
+    local netdev2_num=$1
 
-    get_iface_by_vendor "$host" "$vid" "$did" "$inst1_num"
-    [[ -z "$inst2_num" ]] || get_iface_by_vendor "$host" "$vid" "$did" "$inst2_num"
+    get_iface_by_vendor "$host" "$vid" "$did" "$inst1_num" "$netdev1_num"
+    [[ -z "$inst2_num" ]] \
+        || get_iface_by_vendor "$host" "$vid" "$did" "$inst2_num" "$netdev2_num"
 }
 
 #######################################
@@ -234,7 +247,8 @@ export_ifnames() {
         if [[ -n "$TE_PCI_VENDOR_IUT_TST1" ]] ; then
             ifnames=( $(get_ifnames_by_vendor "$TE_IUT" \
                     "$TE_PCI_VENDOR_IUT_TST1" "$TE_PCI_DEVICE_IUT_TST1" \
-                    "$TE_PCI_INSTANCE_IUT_TST1" "$TE_PCI_INSTANCE_IUT_TST1a") )
+                    "$TE_PCI_INSTANCE_IUT_TST1" "$TE_PCI_FN_NETDEV_IUT_TST1" \
+                    "$TE_PCI_INSTANCE_IUT_TST1a" "$TE_PCI_FN_NETDEV_IUT_TST1a") )
         else
             ifnames=( $(get_ifnames_by_driver "$TE_IUT" \
                     "$TE_ENV_IUT_NET_DRIVER") )
@@ -247,7 +261,8 @@ export_ifnames() {
         if [[ -n "$TE_PCI_VENDOR_TST1_IUT" ]] ; then
             ifnames=( $(get_ifnames_by_vendor "$TE_TST1" \
                     "$TE_PCI_VENDOR_TST1_IUT" "$TE_PCI_DEVICE_TST1_IUT" \
-                    "$TE_PCI_INSTANCE_TST1_IUT" "$TE_PCI_INSTANCE_TST1a_IUT") )
+                    "$TE_PCI_INSTANCE_TST1_IUT" "$TE_PCI_FN_NETDEV_TST1_IUT" \
+                    "$TE_PCI_INSTANCE_TST1a_IUT" "$TE_PCI_FN_NETDEV_TST1a_IUT") )
         else
             ifnames=( $(get_ifnames_by_driver "$TE_TST1" \
                     "$TE_ENV_TST1_NET_DRIVER") )


### PR DESCRIPTION
Now test-environment handles multiple ports on a single PCI function: 
this series of patches adds this support to test suites that use the cns-ts-conf repository.

-------
Tested with cns-net-drv-ts with the following command line:
```console
./scripts/run.sh -q --cfg=<hostname> --tester-run=net-drv-ts/basic/ping
```