### PR TITLE
scripts/iut_os: cope with a two-digit version of the kernel

### DIFF
--- a/scripts/iut_os
+++ b/scripts/iut_os
@@ -482,7 +482,9 @@ done
 
 if test -n "${IUT_KERNEL_VERSION}" ; then
     first_num="$(echo $IUT_KERNEL_VERSION | sed 's/\([0-9]*\)\..*/\1/')"
-    second_num="$(echo $IUT_KERNEL_VERSION | sed 's/[0-9]*\.\([0-9]*\)\..*/\1/')"
+    # Some kernels contain only major and minor version
+    second_num="$(echo $IUT_KERNEL_VERSION | \
+                  sed 's/[0-9]*\.\([0-9]*\)[\.-]\{1\}.*/\1/')"
     export IUT_KERNEL_VERSION_NUM=$((first_num * 100 + $second_num))
 fi
 


### PR DESCRIPTION
Fix the detection of the major and minor versions of the kernel for cases when the kernel contains only major and minor numbers.

OL-Redmine-Id: 13534

-----------------
The patch solves the following errors when running sapi-ts on linux-6.7:
```console
./run.sh -n --cfg=<my-host> --tester-run=sockapi-ts/usecases/read_write
...
/ts-conf/scripts/iut_os: line 486: first_num * 100 + 6.7-amd64: syntax error: invalid arithmetic operator (error token is ".7-amd64")
/ts-conf/scripts/ipvlan: line 15: test: -lt: unary operator expected
/sapi-ts/conf/scripts/sockapi-ts: line 197: test: too many arguments
```