### PR TITLE
cs: add to log listener entries for serial console

### DIFF
--- a/cs/inc.log_listener.yml
+++ b/cs/inc.log_listener.yml
@@ -52,6 +52,9 @@
             - set:
                 - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/parser:iut/port:"
                   value: "${TE_LOG_LISTENER_CONSERVER_PORT:-3109}"
+            - add:
+                - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_IUT_TA_NAME}"
+                  value: "${TE_IUT}"
 
 - cond:
     if: ${TE_LOG_LISTENER_IUT} != ""
@@ -105,6 +108,9 @@
             - set:
                 - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/parser:tst1/port:"
                   value: "${TE_LOG_LISTENER_CONSERVER_PORT:-3109}"
+            - add:
+                - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_TST1_TA_NAME}"
+                  value: "${TE_TST1}"
 
 - cond:
     if: ${TE_LOG_LISTENER_TST1} != ""


### PR DESCRIPTION
In the case of conserver, tests may want to not only read data from the console, but also write to it. TE provides special functions for this, which use the configurator entries added by this patch.

OL-Redmine-Id: 14094

------------------------------------------------
The sockapi-ts/prologue is still green