### PR TITLE
cs: move the serial console items to a separate file

### DIFF
--- a/cs/inc.log_listener.yml
+++ b/cs/inc.log_listener.yml
@@ -52,9 +52,6 @@
             - set:
                 - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/parser:iut/port:"
                   value: "${TE_LOG_LISTENER_CONSERVER_PORT:-3109}"
-            - add:
-                - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_IUT_TA_NAME}"
-                  value: "${TE_IUT}"
 
 - cond:
     if: ${TE_LOG_LISTENER_IUT} != ""
@@ -108,9 +105,6 @@
             - set:
                 - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/parser:tst1/port:"
                   value: "${TE_LOG_LISTENER_CONSERVER_PORT:-3109}"
-            - add:
-                - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_TST1_TA_NAME}"
-                  value: "${TE_TST1}"
 
 - cond:
     if: ${TE_LOG_LISTENER_TST1} != ""

--- a/cs/inc.serial_console.yml
+++ b/cs/inc.serial_console.yml
@@ -1,0 +1,29 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2025 OKTET Labs Ltd.
+#
+# Serial console reader/writer control. As a rule, the file should be used
+# together with inc.log_listener.yml file.
+# With this file, tests can not only read, but also write to the console
+# using serial console TE TAPI.
+#
+
+#
+# IUT serial console via conserver
+#
+- cond:
+    if: ${TE_LOG_LISTENER_IUT} = conserver
+    then:
+      - add:
+        - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_IUT_TA_NAME}"
+          value: "${TE_IUT}"
+
+#
+# TST1 serial console via conserver
+#
+- cond:
+    if: ${TE_LOG_LISTENER_TST1} = conserver
+    then:
+      - add:
+        - oid: "/agent:${TE_LOG_LISTENER_TA_NAME}/console:${TE_TST1_TA_NAME}"
+          value: "${TE_TST1}"


### PR DESCRIPTION
This should be in a separate file, because these items are also registered in a separate TE file and also require the building of a special TE library.

OL-Redmine-Id: 14094
Fixes: 884560d71868 ("cs: add to log listener entries for serial console")
