### PR TITLE
rcf: allow enabling time synchronization

### DIFF
--- a/rcf.conf
+++ b/rcf.conf
@@ -4,7 +4,8 @@
 <rcf>
     <ta name="${TE_IUT_TA_NAME}" type="${TE_IUT_TA_TYPE:-linux}"
         disabled="${TE_IUT:-${TE_IUT_LOCALHOST:-yes}}" rcflib="rcfunix"
-        rebootable="${TE_IUT_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_IUT}">
+        rebootable="${TE_IUT_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_IUT}"
+        synch_time="${TE_IUT_SYNCH_TIME:-no}">
         <conf name="host">${TE_IUT}</conf>
         <conf name="port">${TE_IUT_PORT:-${TE_RCF_PORT:-50000}}</conf>
         <conf name="user">${TE_IUT_SSH_USER:-${TE_SSH_USER}}</conf>
@@ -21,7 +22,8 @@
     </ta>
     <ta name="${TE_IUT_SOC_TA_NAME}" type="${TE_IUT_SOC_TA_TYPE:-linux}"
         disabled="${TE_IUT_SOC:-${TE_IUT_SOC_LOCALHOST:-yes}}" rcflib="rcfunix"
-        rebootable="${TE_IUT_SOC_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_IUT_SOC}">
+        rebootable="${TE_IUT_SOC_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_IUT_SOC}"
+        synch_time="${TE_IUT_SOC_SYNCH_TIME:-no}">
         <conf name="host">${TE_IUT_SOC}</conf>
         <conf name="port">${TE_IUT_SOC_PORT:-${TE_RCF_PORT:-50000}}</conf>
         <conf name="user">${TE_IUT_SOC_SSH_USER:-${TE_SSH_USER}}</conf>
@@ -38,7 +40,8 @@
     </ta>
     <ta name="${TE_TST1_TA_NAME}" type="${TE_TST1_TA_TYPE:-linux}"
         disabled="${TE_TST1:-${TE_TST1_LOCALHOST:-yes}}" rcflib="rcfunix"
-        rebootable="${TE_TST1_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST1}">
+        rebootable="${TE_TST1_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST1}"
+        synch_time="${TE_TST1_SYNCH_TIME:-no}">
         <conf name="host">${TE_TST1}</conf>
         <conf name="port">${TE_TST1_PORT:-${TE_RCF_PORT:-50000}}</conf>
         <conf name="user">${TE_TST1_SSH_USER:-${TE_SSH_USER}}</conf>
@@ -62,7 +65,8 @@
     </ta>
     <ta name="${TE_TST2_TA_NAME}" type="${TE_TST2_TA_TYPE:-linux}"
         disabled="${TE_TST2:-${TE_TST2_LOCALHOST:-yes}}" rcflib="rcfunix"
-        rebootable="${TE_TST2_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST2}">
+        rebootable="${TE_TST2_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST2}"
+        synch_time="${TE_TST2_SYNCH_TIME:-no}">
         <conf name="host">${TE_TST2}</conf>
         <conf name="port">${TE_TST2_PORT:-${TE_RCF_PORT:-50000}}</conf>
         <conf name="user">${TE_TST2_SSH_USER:-${TE_SSH_USER}}</conf>
@@ -92,7 +96,8 @@
     </ta>
     <ta name="${TE_TST3_TA_NAME}" type="${TE_TST3_TA_TYPE:-linux}"
         disabled="${TE_TST3:-${TE_TST3_LOCALHOST:-yes}}" rcflib="rcfunix"
-        rebootable="${TE_TST3_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST3}">
+        rebootable="${TE_TST3_REBOOTABLE}" cold_reboot="${TE_POWER_TA_NAME}:${TE_TST3}"
+        synch_time="${TE_TST3_SYNCH_TIME:-no}">
         <conf name="host">${TE_TST3}</conf>
         <conf name="port">${TE_TST3_PORT:-${TE_RCF_PORT:-50000}}</conf>
         <conf name="user">${TE_TST3_SSH_USER:-${TE_SSH_USER}}</conf>


### PR DESCRIPTION
Add the sync_time parameter for all main Test Agents to allow enabling or disabling time synchronization between the Test Engine and a Test Agent.

The time synchronization is still disabled by default.
