### PR TITLE
cs: allocate hugepages for DPDK EthDev TS automatically

### DIFF
--- a/cs/dpdk-pmd-ts.yml
+++ b/cs/dpdk-pmd-ts.yml
@@ -18,6 +18,7 @@
     - cm_volatile.yml
     - cm_module.yml
     - cm_l4_port.yml
+    - cm_mem.yml
 
 - include:
     - inc.conf_delay.yml
@@ -66,6 +67,7 @@
     - inc.misc.yml
     - inc.prevent_netdrv_autobind.yml
     - inc.local_module.yml
+    - inc.hugepages.yml
 
 - cond:
     if: ${TE_IUT_SETUP_VFS} = 1

--- a/cs/inc.hugepages.yml
+++ b/cs/inc.hugepages.yml
@@ -1,0 +1,75 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+- cond:
+    if: ${TE_IUT_HUGEPAGES_1G_NUM} != ""
+    then:
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/rsrc:hugepage-1048576"
+          value: /agent:${TE_IUT_TA_NAME}/mem:/hugepages:1048576
+
+      - set:
+        - oid: "/agent:${TE_IUT_TA_NAME}/mem:/hugepages:1048576"
+          value: "${TE_IUT_HUGEPAGES_1G_NUM}"
+
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/rsrc:mountpoint-1g"
+          value: /agent:${TE_IUT_TA_NAME}/mem:/hugepages:1048576/mountpoint:$dev$hugepages-1G
+
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/mem:/hugepages:1048576/mountpoint:$dev$hugepages-1G"
+
+- cond:
+    if: ${TE_IUT_HUGEPAGES_2K_NUM} != ""
+    then:
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/rsrc:hugepage-2048"
+          value: /agent:${TE_IUT_TA_NAME}/mem:/hugepages:2048
+
+      - set:
+        - oid: "/agent:${TE_IUT_TA_NAME}/mem:/hugepages:2048"
+          value: "${TE_IUT_HUGEPAGES_2K_NUM}"
+
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/rsrc:mountpoint-2m"
+          value: /agent:${TE_IUT_TA_NAME}/mem:/hugepages:2048/mountpoint:$dev$hugepages-2M
+
+      - add:
+        - oid: "/agent:${TE_IUT_TA_NAME}/mem:/hugepages:2048/mountpoint:$dev$hugepages-2M"
+
+- cond:
+    if: ${TE_TST1_HUGEPAGES_1G_NUM} != ""
+    then:
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/rsrc:hugepage-1048576"
+          value: /agent:${TE_TST1_TA_NAME}/mem:/hugepages:1048576
+
+      - set:
+        - oid: "/agent:${TE_TST1_TA_NAME}/mem:/hugepages:1048576"
+          value: "${TE_TST1_HUGEPAGES_1G_NUM}"
+
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/rsrc:mountpoint-1g"
+          value: /agent:${TE_TST1_TA_NAME}/mem:/hugepages:1048576/mountpoint:$dev$hugepages-1G
+
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/mem:/hugepages:1048576/mountpoint:$dev$hugepages-1G"
+
+- cond:
+    if: ${TE_TST1_HUGEPAGES_2K_NUM} != ""
+    then:
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/rsrc:hugepage-2048"
+          value: /agent:${TE_TST1_TA_NAME}/mem:/hugepages:2048
+
+      - set:
+        - oid: "/agent:${TE_TST1_TA_NAME}/mem:/hugepages:2048"
+          value: "${TE_TST1_HUGEPAGES_2K_NUM}"
+
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/rsrc:mountpoint-2m"
+          value: /agent:${TE_TST1_TA_NAME}/mem:/hugepages:2048/mountpoint:$dev$hugepages-2M
+
+      - add:
+        - oid: "/agent:${TE_TST1_TA_NAME}/mem:/hugepages:2048/mountpoint:$dev$hugepages-2M"


### PR DESCRIPTION
DPDK requires pre-allocated hugepages. Do not rely on the host configuration, but try to allocate hugepages automatically when requested in the configuration files.
