### PR TITLE
opts: remove TRC tag for maximum Rx queue number

### DIFF
--- a/opts/virtio_virtio
+++ b/opts/virtio_virtio
@@ -2,8 +2,6 @@
 --script=scripts/virtio_virtio
 --script=scripts/fix-ssh-keys-perm
 
---trc-tag=max_rx_queues:1
---trc-tag=max_tx_queues:1
 --trc-tag=qemu-virtio-net
 --trc-tag=peer-qemu-virtio-net
 

--- a/opts/xilinx-virtio-net
+++ b/opts/xilinx-virtio-net
@@ -5,5 +5,3 @@
 
 --trc-tag=xilinx-virtio-net
 #--trc-tag=virtio-net-no-ctrl-q
---trc-tag=max_rx_queues:8
---trc-tag=max_tx_queues:8


### PR DESCRIPTION
All Test Suites add these tags based on the real information in the main prologue.